### PR TITLE
Update rate limit to 10r/s

### DIFF
--- a/templates/nginx.conf
+++ b/templates/nginx.conf
@@ -1,4 +1,4 @@
-limit_req_zone $binary_remote_addr zone={{domain}}_ratelimit:10m rate=1r/s;
+limit_req_zone $binary_remote_addr zone={{domain}}_ratelimit:10m rate=10r/s;
 
 server {
     listen 80;


### PR DESCRIPTION
Since nginx is serving up a bunch of images the rate limiter seems to be hitting more than usual and giving the end users 500 errors. This ups the rate to 10 requests per second which should help.